### PR TITLE
FOGL-3554: plugin_reason includes tigger time and asset information

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -308,10 +308,14 @@ bool plugin_eval(PLUGIN_HANDLE handle,
 string plugin_reason(PLUGIN_HANDLE handle)
 {
 	OutOfBound* rule = (OutOfBound *)handle;
+	BuiltinRule::TriggerInfo info;
+	rule->getFullState(info);
 
 	string ret = "{ \"reason\": \"";
-	ret += rule->getState() == OutOfBound::StateTriggered ? "triggered" : "cleared";
-	ret += "\" }";
+	ret += info.getState() == BuiltinRule::StateTriggered ? "triggered" : "cleared";
+	ret += "\"";
+	ret += ", \"asset\": " + info.getAssets() + ", \"timestamp\": \"" + info.getUTCDateTime() + "\"";
+	ret += " }";
 
 	return ret;
 }


### PR DESCRIPTION
FOGL-3554: plugin_reason includes tigger time and asset information

This change needs branch FOGL-3554 of foglamp-service-notification

Example output with two asset configured in a rule

`{ "reason": "cleared", "asset": ["randomwalk", "sinusoid"], "timestamp": "2019-12-31 15:53:01.263673+00:00" }`